### PR TITLE
fix: arm64 build @next/swc-darwin-arm64

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}


### PR DESCRIPTION
Great stream guys... Tried running the code and encountered this issue. Here's a `quick-fix`.


Error:
```bash
✓ Linting and checking validity of types    
⚠ Attempted to load @next/swc-darwin-arm64, but an error occurred: 
⨯ Failed to load SWC binary for darwin/arm64, see more info here: https://nextjs.org/docs/messages/failed-loading-swc
   Creating an optimized production build  .%   
```
Simple Fix:
- Next build on arm64 failing, fixed by opt-out by disabling `swcMinify`